### PR TITLE
Upgrade to actions/setup-node@v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
     - run: npm i -g neonctl@v1
       shell: bash
     - name: Delete branch


### PR DESCRIPTION
As per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20, all github actions need to migrate to Node v20.

Upgrading the `setup-node` to v4 will take care of that.