### PR TITLE
Update actions/setup-node to v6

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
     - run: npm i -g neonctl@v2
       shell: bash
     - name: Delete branch


### PR DESCRIPTION
This _should_ eliminate the following warning:
<img width="1441" height="602" alt="image" src="https://github.com/user-attachments/assets/bfd36180-827f-4306-9c54-97d0265bd6b1" />

See the [actions/setup-node changelog](https://github.com/actions/setup-node/releases).

Note that this should be included in a v4 release as the Node version update is potentially a breaking change.
